### PR TITLE
Update case sensitive module import path

### DIFF
--- a/src/NodeRTLib/JsPackageFiles/main.js
+++ b/src/NodeRTLib/JsPackageFiles/main.js
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 var path = require('path');
@@ -14,7 +14,7 @@ try {
   if (fs.existsSync(path.join(__dirname, '{ProjectName}.d.js)'))) {
     module.exports = require('./{ProjectName}.d.js');
   }
-  module.exports = require('../build/release/binding.node');
+  module.exports = require('../build/Release/binding.node');
 }
 catch(e) {
   throw e;


### PR DESCRIPTION
This PR updates import path of compile native module to honor case-sensitive path,
from
`'../build/release/binding.node'`

to
`'../build/Release/binding.node'`

as build project creates release output same case sensitive path.

Normal usage case, this doesn't affect at all since windows does not honor case-sensitive. This solves particular usecases of `electron` based application creates application package using `asar`, which does honor case so could lead module lookup fails.