### PR TITLE
Fix RemoveListener template event name check

### DIFF
--- a/src/NodeRTLib/CppTemplates/Event.cpp
+++ b/src/NodeRTLib/CppTemplates/Event.cpp
@@ -77,7 +77,7 @@
       String::Value eventName(info[0]);
       auto str = *eventName;
 
-      if (@TX.ForEachEvent(Model.Events ,"(NodeRT::Utils::CaseInsenstiveEquals(L\"{1}\", str)) &&", 3))
+      if (@TX.ForEachEvent(Model.Events ,"(!NodeRT::Utils::CaseInsenstiveEquals(L\"{1}\", str)) &&", 3))
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;


### PR DESCRIPTION
The `RemoveListener` template had reversed logic for checking the event name, so it would always reject valid event names.

I found this bug with the [`noble-uwp`](https://github.com/jasongin/noble-uwp) project that uses NodeRT.