### PR TITLE
Fix TryCatch scoping

### DIFF
--- a/src/NodeRTLib/CppTemplates/MemberAsyncMethod.cpp
+++ b/src/NodeRTLib/CppTemplates/MemberAsyncMethod.cpp
@@ -97,29 +97,30 @@
               else
               {
                   var jsConversionInfo = Converter.ToJS(taskReturnType, TX.MainModel.Types.ContainsKey(taskReturnType)); 
-            @:TryCatch tryCatch;
-            @:Local<Value> error; 
-            @:Local<Value> arg1 = @string.Format(jsConversionInfo[1], "result");
 
-            @:if (tryCatch.HasCaught())
-            @:{
-            @:  error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
-            @:}
-            @:else 
-            @:{
-            @:  error = Undefined();
-            @:}
+            @:Local<Value> error;
+            @:Local<Value> arg1;
 
-            @:if (arg1.IsEmpty()) arg1 = Undefined();
+            @:{
+              @:TryCatch tryCatch;
+              @:arg1 = @string.Format(jsConversionInfo[1], "result");
+
+              @:if (tryCatch.HasCaught())
+              @:{
+              @:  error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
+              @:}
+              @:else 
+              @:{
+              @:  error = Undefined();
+              @:}
+
+              @:if (arg1.IsEmpty()) arg1 = Undefined();
+            @:}
 
             @:Local<Value> args[] = {error, arg1};
-			@:// TODO: this is ugly! Needed due to the possibility of expception occuring inside object convertors
-			@:// can be fixed by wrapping the conversion code in a function and calling it on the fly
-			@:// we must clear the try catch block here so the invoked inner method exception won't get swollen (issue #52) 
-			@:tryCatch.~TryCatch();
               }
             }
-		    
+
             invokeCallback(_countof(args), args);
           });
         }

--- a/src/NodeRTLib/CppTemplates/RegisterEventWithWinRT.cpp
+++ b/src/NodeRTLib/CppTemplates/RegisterEventWithWinRT.cpp
@@ -29,37 +29,32 @@
             ref new @(TX.ToWinRT(Model.EventInfo.EventHandlerType,false))(
             [callbackObjPtr](@foreachArg("{1} arg{2}, ", 2)) {
               NodeUtils::Async::RunOnMain([callbackObjPtr @foreachArg(", arg{2}", 0)]() {
-           	    HandleScope scope;
-                TryCatch tryCatch;
-              
-                Local<Value> error;
-                @{var j = 0;}
+                HandleScope scope;
+
+                @{var k = 0;}
                 @foreach (var type in eventArgs)
                 {
-                 var jsConversionInfo = Converter.ToJS(type, TX.MainModel.Types.ContainsKey(type)); 
-                @:Local<Value> wrappedArg@(j) = @(string.Format(jsConversionInfo[1], String.Format("arg{0}",j )));
-                  j++;
+                @:Local<Value> wrappedArg@(k);
+                  k++;
                 }
 
-                if (tryCatch.HasCaught())
                 {
-                  error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
-                }
-                else 
-                {
-                  error = Undefined();
-                }
+                  TryCatch tryCatch;
 
-				// TODO: this is ugly! Needed due to the possibility of expception occuring inside object convertors
-				// can be fixed by wrapping the conversion code in a function and calling it on the fly
-				// we must clear the try catch block here so the invoked inner method exception won't get swollen (issue #52) 
-				tryCatch.~TryCatch();
+                  @{var j = 0;}
+                  @foreach (var type in eventArgs)
+                  {
+                    var jsConversionInfo = Converter.ToJS(type, TX.MainModel.Types.ContainsKey(type)); 
+                  @:wrappedArg@(j) = @(string.Format(jsConversionInfo[1], String.Format("arg{0}", j)));
+                    j++;
+                  }
 
-                @{var i = 0;}
-                @foreach (var type in eventArgs)
-                {
-                @:if (wrappedArg@(i).IsEmpty()) wrappedArg@(i) = Undefined();
-                  i++;
+                  @{var i = 0;}
+                  @foreach (var type in eventArgs)
+                  {
+                  @:if (wrappedArg@(i).IsEmpty()) wrappedArg@(i) = Undefined();
+                    i++;
+                  }
                 }
 
                 @if (eventArgs.Length > 0)

--- a/src/NodeRTLib/CppTemplates/StaticAsyncMethod.cpp
+++ b/src/NodeRTLib/CppTemplates/StaticAsyncMethod.cpp
@@ -89,30 +89,31 @@
               }
               else
               {
-                  var jsConversionInfo = Converter.ToJS(taskReturnType, TX.MainModel.Types.ContainsKey(taskReturnType)); 
-            @:TryCatch tryCatch;
+                var jsConversionInfo = Converter.ToJS(taskReturnType, TX.MainModel.Types.ContainsKey(taskReturnType));
+
             @:Local<Value> error; 
-            @:Local<Value> arg1 = @string.Format(jsConversionInfo[1], "result");
+            @:Local<Value> arg1;
 
-            @:if (tryCatch.HasCaught())
             @:{
-            @:  error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
-            @:}
-            @:else 
-            @:{
-            @:  error = Undefined();
-            @:}
+              @:TryCatch tryCatch;
+              @:arg1 = @string.Format(jsConversionInfo[1], "result");
 
-            @:if (arg1.IsEmpty()) arg1 = Undefined();
+              @:if (tryCatch.HasCaught())
+              @:{
+              @:  error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
+              @:}
+              @:else 
+              @:{
+              @:  error = Undefined();
+              @:}
+
+              @:if (arg1.IsEmpty()) arg1 = Undefined();
+            @:}
 
             @:Local<Value> args[] = {error, arg1};
-			@:// TODO: this is ugly! Needed due to the possibility of expception occuring inside object convertors
-			@:// can be fixed by wrapping the conversion code in a function and calling it on the fly
-			@:// we must clear the try catch block here so the invoked inner method exception won't get swollen (issue #52) 
-			@:tryCatch.~TryCatch();
               }
             }
-	  	    
+
             invokeCallback(_countof(args), args);
           });
         }


### PR DESCRIPTION
Change to using block scoping around the `TryCatch` instead of an explicit call to the destructor. The latter was causing the destructor to be invoked twice, where the second invocation was when the `TryCatch` exited scope. That double-destruction results in a fatal error in **Debug** builds of node at [v8::Isolate::UnregisterTryCatchHandler()](https://github.com/nodejs/node/blob/master/deps/v8/src/isolate.cc#L282). (I think it didn't cause any problem in **Release** builds of node. But at least this fixes the "ugly" code.)

I tested this by re-generating code for the 7 namespaces used by [noble-uwp](https://github.com/jasongin/noble-uwp). After this fix, it no longer hits the fatal error on debug node.