### PR TITLE
Use URIs instead of filepaths

### DIFF
--- a/src/NodeRTLib/NodeRTProjectGenerator.cs
+++ b/src/NodeRTLib/NodeRTProjectGenerator.cs
@@ -199,7 +199,9 @@ namespace NodeRTLib
                 !directoryName.EndsWith(@"windows kits\8.0\references\commonconfiguration\neutral") &&
                 !directoryName.EndsWith(@"windows kits\10\unionmetadata"))
             {
-                bindingFileText.Replace("{AdditionalWinmdPath}", Path.GetDirectoryName(winrtFile));
+                var winmdModulePath = Path.GetDirectoryName(winrtFile);
+                var winmdModuleUri = new System.Uri(winmdModulePath).AbsolutePath;
+                bindingFileText.Replace("{AdditionalWinmdPath}", winmdModuleUri);
                 bindingFileText.Replace("{UseAdditionalWinmd}", "true");
             }
             else


### PR DESCRIPTION
Fixes the generated node gyp binding file to use a URI path instead of a filepath, which was causing installations to fail with: ```The project file could not be loaded. ', hexadecimal value 0x08
, is an invalid character. Line 52, position 306.```