### PR TITLE
Enable compilation with VS 2017

### DIFF
--- a/src/NodeRTLib/ProjectTemplates/binding.gyp
+++ b/src/NodeRTLib/ProjectTemplates/binding.gyp
@@ -44,10 +44,8 @@
           'msvs_settings': {
             'VCCLCompilerTool': {
               'AdditionalUsingDirectories' : [
-                '%ProgramFiles(x86)%/Microsoft Visual Studio 14.0/VC/lib/store/references',
-				'%ProgramFiles(x86)%/Windows Kits/10/UnionMetadata',
-				'%ProgramFiles%/Microsoft Visual Studio 14.0/VC/lib/store/references',
-				"%ProgramFiles%/Windows Kits/10/UnionMetadata"]
+                '$(VC_ReferencesPath_VC_x86)/store/references',
+                '$(WindowsSDK_UnionMetadataPath)']
               }
             }
           }],


### PR DESCRIPTION
This patch fixes errors when building with VS 2017. (#65)
Because it uses macros, it expands to the correct path for both VS 2015 and VS 2017 on x86 and x64.