### PR TITLE
Fix path seperator for bindings.gyp

### DIFF
--- a/src/NodeRTLib/NodeRTProjectGenerator.cs
+++ b/src/NodeRTLib/NodeRTProjectGenerator.cs
@@ -199,9 +199,9 @@ namespace NodeRTLib
                 !directoryName.EndsWith(@"windows kits\8.0\references\commonconfiguration\neutral") &&
                 !directoryName.EndsWith(@"windows kits\10\unionmetadata"))
             {
-                var winmdModulePath = Path.GetDirectoryName(winrtFile);
-                var winmdModuleUri = new System.Uri(winmdModulePath).AbsolutePath;
-                bindingFileText.Replace("{AdditionalWinmdPath}", winmdModuleUri);
+                var winmdDirectory = Path.GetDirectoryName(winrtFile);
+                var additionalWinmdPath = winmdDirectory.Replace('\\', '/');
+                bindingFileText.Replace("{AdditionalWinmdPath}", additionalWinmdPath);
                 bindingFileText.Replace("{UseAdditionalWinmd}", "true");
             }
             else


### PR DESCRIPTION
When installing `@nodert-win10-cu/windows.system.diagnostics`, I got the following error:

```
error MSB4025: The project file could not be loaded. ', hexadecimal value 0x08
, is an invalid character. Line 52, position 306.
```

This error occured in the `binding.vcxproj` file with the following obviously broken string:

```
C:\Program Files (x86)\Windows Kits\UnionMetadata.0.17134.0
```

I found this broken string resulted from the following lines in `binding.gyp`:

```
'AdditionalUsingDirectories' : [
  'C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.17134.0'
]
```

All other paths in this file had forward slashes, only this path had backwards slashes.

So I fixed the code that generated this path with a simple `.Replace('\\', '/')`.

When I used NodeRT to build `windows.system.diagnostics` afterwards, it worked just fine.

Any feedback would be much appreciated!