### PR TITLE
FEATURE: Full Support for Windows 10 Redstone 4 (17134) & Visual Studio 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,15 @@ If you just want to consume modules, you can install them directly from npm.
 
 :computer: Example
 ```
-npm install --save @nodert-win10-au/windows.applicationmodel
-npm install --save @nodert-win10-au/windows.web.http
+npm install --save @nodert-win10-rs4/windows.ui.notifications
 ```
 
 | SDK | Windows Version | npm Scope |
 | --- | --- | --- |
-| Windows 10, Build 10586 (Threshold 2) | 1511 | [npmjs.com/~nodert-win10](https://www.npmjs.com/~nodert-win10) |
-| Windows 10, Build 14393 (Anniversary Update) | 1607 | [npmjs.com/org/nodert-win10-au](https://www.npmjs.com/org/nodert-win10-au) |
-| Windows 10, Build 15063 (Creators Update) | 1703 | [npmjs.com/org/nodert-win10-cu](https://www.npmjs.com/org/nodert-win10-cu) |
-| Windows 10, Build 16xxx (Fall Creators Update) | -- | (Not released yet) |
+| Windows 10, Build 17134 | Redstone 4 | 1803 | [npmjs.com/org/nodert-win10-rs4](https://www.npmjs.com/org/nodert-win10-rs4) |
+| Windows 10, Build 15063 | Creators Update | 1703 | [npmjs.com/org/nodert-win10-cu](https://www.npmjs.com/org/nodert-win10-cu) |
+| Windows 10, Build 14393 | Anniversary Update | 1607 | [npmjs.com/org/nodert-win10-au](https://www.npmjs.com/org/nodert-win10-au) |
+| Windows 10, Build 10586 | Threshold 2 | 1511 | [npmjs.com/~nodert-win10](https://www.npmjs.com/~nodert-win10) |
 
 <H4><b>[New!] You can now learn about NodeRT by watching the MS Build 2017 talk: <a href="https://channel9.msdn.com/Events/Build/2017/T6976">"NodeRT: Using native Windows features from Node.js and Electron"</a>.</b></H4>
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ For more examples of what NodeRT can do, check out our <a href="/samples">sample
 First, in order to use WinRT you must be running on a Windows environment that supports WinRT- meaning Windows 10, Windows 8.1, Windows 8, or Windows Server 2012.
 
 In order to use NodeRT, make sure you have the following installed:<br>
-* Visual Studio 2015, or <a href="https://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx">VS 2015 Express for Windows Desktop</a>, for generating Windows 10 compatible modules, or Visual Studio 2013/2012 for generating Windows 8.1/8 compatible modules repsectively.<br>
+* Visual Studio 2017 or 2015 for generating Windows 10 compatible modules<br>
+* Visual Studio 2013 or 2012 for generating Windows 8.1/8 compatible modules repsectively.<br>
 * Windows SDK for the version of Windows your are using:
 	- [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
 	- [Windows 8.1 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-8-1-sdk)
@@ -134,7 +135,7 @@ The following is the list of options that the tool supports:
  --outdir [path]             The output dir in which the compiled NodeRT module
                              will be created in
 
- --vs [Vs2015|Vs2013|Vs2012] Optional, VS version to use, default is Vs2015
+ --vs [Vs2017|Vs2015|Vs2013|Vs2012] Optional, VS version to use, default is Vs2017
  
  --winver [10|8.1|8]         Optional, Windows SDK version to use, default is 10
 

--- a/src/NodeRTCmd/Program.cs
+++ b/src/NodeRTCmd/Program.cs
@@ -57,14 +57,14 @@ namespace NodeRTCmd
             string ns = ValueOrNull(argsDictionary, "namespace");
             string customWinMdDir = ValueOrNull(argsDictionary, "customwinmddir");
 
-            VsVersions vsVersion = VsVersions.Vs2015;
+            VsVersions vsVersion = VsVersions.Vs2017;
             WinVersions winVersion = WinVersions.v10;
 
             if (argsDictionary.ContainsKey("vs"))
             {
                 if (!Enum.TryParse<VsVersions>(argsDictionary["vs"], true, out vsVersion))
                 {
-                    Console.WriteLine("Unssuported VS version. Supported options are: VS2015, VS2013, VS2012");
+                    Console.WriteLine("Unsupported VS version. Supported options are: VS2017, VS2015, VS2013, VS2012");
                     Environment.Exit(1);
                 }
             }
@@ -236,7 +236,7 @@ namespace NodeRTCmd
             Console.WriteLine("  --outdir [path]              The output dir in which the NodeRT module");
             Console.WriteLine("                               will be created in");
             Console.WriteLine();
-            Console.WriteLine("  --vs [Vs2015|Vs2013|Vs2012]  Optional, VS version to use, default is Vs2015");
+            Console.WriteLine("  --vs [Vs2017|Vs2015|Vs2013|Vs2012]  Optional, VS version to use, default is Vs2017");
             Console.WriteLine();
             Console.WriteLine("  --winver [10|8.1|8]          Optional, Windows SDK version to use, default is 10");
             Console.WriteLine();

--- a/src/NodeRTLib/JsPackageFiles/README.md
+++ b/src/NodeRTLib/JsPackageFiles/README.md
@@ -36,7 +36,7 @@ In order to install this module, run npm install:
 npm install {PackageName}
 ```
 
-If you wish to rebuild this module using node-gyp, make sure to use the appropriate VS version using --msvs_version=2012/2013/2015 flag:
+If you wish to rebuild this module using node-gyp, make sure to use the appropriate VS version using --msvs_version=2012/2013/2015/2017 flag:
 
 For example:
 

--- a/src/NodeRTLib/NodeRTProjectBuildUtils.cs
+++ b/src/NodeRTLib/NodeRTProjectBuildUtils.cs
@@ -44,6 +44,9 @@ namespace NodeRTLib
                 case VsVersions.Vs2015:
                     versionString = "2015";
                     break;
+                case VsVersions.Vs2017:
+                    versionString = "2017";
+                    break;
                 default:
                     throw new Exception("Unknown VS Version");
             }

--- a/src/NodeRTLib/NodeRTProjectGenerator.cs
+++ b/src/NodeRTLib/NodeRTProjectGenerator.cs
@@ -20,7 +20,8 @@ namespace NodeRTLib
     {
         Vs2012,
         Vs2013,
-        Vs2015
+        Vs2015,
+        Vs2017
     }
 
     public enum WinVersions
@@ -90,8 +91,10 @@ namespace NodeRTLib
                     return "2012";
                 case VsVersions.Vs2013:
                     return "2013";
-                default:
+                case VsVersions.Vs2015:
                     return "2015";
+                default:
+                    return "2017";
             }
         }
 
@@ -261,8 +264,10 @@ namespace NodeRTLib
                 packageJsonFileText.Replace("{VSVersion}", "2012");
             else if (_vsVersion == VsVersions.Vs2013)
                 packageJsonFileText.Replace("{VSVersion}", "2013");
-            else
+            else if (_vsVersion == VsVersions.Vs2015)
                 packageJsonFileText.Replace("{VSVersion}", "2015");
+            else
+                packageJsonFileText.Replace("{VSVersion}", "2017");
 
             File.WriteAllText(Path.Combine(destinationFolder, "package.json"), packageJsonFileText.ToString());
 

--- a/src/NodeRTUI/App.config
+++ b/src/NodeRTUI/App.config
@@ -18,7 +18,7 @@
                 <value />
             </setting>
             <setting name="VsVersionComboSelection" serializeAs="String">
-                <value>2</value>
+                <value>3</value>
             </setting>
             <setting name="OutputDirPath" serializeAs="String">
                 <value />

--- a/src/NodeRTUI/MainForm.Designer.cs
+++ b/src/NodeRTUI/MainForm.Designer.cs
@@ -251,7 +251,8 @@ namespace NodeRTUI
             this.cmbVsVersion.Items.AddRange(new object[] {
             "VS 2012 Project",
             "VS 2013 Project",
-            "VS 2015 Project"});
+            "VS 2015 Project",
+            "VS 2017 Project"});
             this.cmbVsVersion.Location = new System.Drawing.Point(193, 306);
             this.cmbVsVersion.Name = "cmbVsVersion";
             this.cmbVsVersion.Size = new System.Drawing.Size(343, 21);

--- a/src/NodeRTUI/MainForm.cs
+++ b/src/NodeRTUI/MainForm.cs
@@ -88,7 +88,7 @@ namespace NodeRTUI
         {
             Properties.Settings.Default.LastWinMDPath = "";
             Properties.Settings.Default.LastFilter = "";
-            Properties.Settings.Default.VsVersionComboSelection = 2;
+            Properties.Settings.Default.VsVersionComboSelection = 3;
             Properties.Settings.Default.OutputDirPath = GetDefaultOutputDir();
             Properties.Settings.Default.GenerateDefsChk = true;
             Properties.Settings.Default.Save();
@@ -98,7 +98,7 @@ namespace NodeRTUI
             txtFilter.Text = "";
             txtOutputDirectory.Text = Properties.Settings.Default.OutputDirPath;
             cmbWindowsVersion.SelectedIndex = 2;
-            cmbVsVersion.SelectedIndex = 2;
+            cmbVsVersion.SelectedIndex = 3;
             chkDefGen.Checked = true;
             chkBuildModule.Checked = true;
             namespaceList.Items.Clear();

--- a/src/NodeRTUI/Properties/Settings.Designer.cs
+++ b/src/NodeRTUI/Properties/Settings.Designer.cs
@@ -49,7 +49,7 @@ namespace NodeRTUI.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("2")]
+        [global::System.Configuration.DefaultSettingValueAttribute("3")]
         public int VsVersionComboSelection {
             get {
                 return ((int)(this["VsVersionComboSelection"]));

--- a/src/NodeRTUI/Properties/Settings.settings
+++ b/src/NodeRTUI/Properties/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="VsVersionComboSelection" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">2</Value>
+      <Value Profile="(Default)">3</Value>
     </Setting>
     <Setting Name="OutputDirPath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />


### PR DESCRIPTION
Dear team;

as i required a Windows notification module for an Electron project, discovered that this modules' platform support was hopelessly outdated  - and thus i ended up upgrading the codebase to work with contemporary platforms, such as Windows 10 (Redstone 4) and VS 2017.

This PR

 - adds VS2017 as the new default VS version in all NodeRT subprojects
 - has been tested with with the current RS4 SDK on insider preview and stable
 - I created the [@nodert-win10-rs4](https://www.npmjs.com/org/nodert-win10-rs4) npm organization for archiving built modules 
 - have updated the documentation accordingly

I tried to follow existing conventions wherever possible.
Looking forward to your feedback! 

Kind regards,
S