### PR TITLE
Add support for VS 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ $RECYCLE.BIN/
 
 # VS2017
 src/.vs/NodeRT/v15
+
+# VS2019
+src/.vs/NodeRT/v16

--- a/MODULE_CREATION.md
+++ b/MODULE_CREATION.md
@@ -37,7 +37,7 @@ locator.getGeopositionAsync((error, result) => {
 First, in order to use WinRT you must be running on a Windows environment that supports WinRT - meaning Windows 10, Windows 8.1, Windows 8, or Windows Server 2012.
 
 In order to use NodeRT, make sure you have the following installed:<br>
-* Visual Studio 2017 or 2015 for generating Windows 10 compatible modules<br>
+* Visual Studio 2019, 2017, or 2015 for generating Windows 10 compatible modules<br>
 * Visual Studio 2013 or 2012 for generating Windows 8.1/8 compatible modules respectively.
 * Windows SDK for the version of Windows your are using:
 	- [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
@@ -102,7 +102,7 @@ The following is the list of options that the tool supports:
  --outdir [path]             The output dir in which the compiled NodeRT module
                              will be created in
 
- --vs [Vs2017|Vs2015|Vs2013|Vs2012] Optional, VS version to use, default is Vs2017
+ --vs [Vs2019|Vs2017|Vs2015|Vs2013|Vs2012] Optional, VS version to use, default is Vs2019
 
  --winver [10|8.1|8]         Optional, Windows SDK version to use, default is 10
 

--- a/src/NodeRTCmd/Program.cs
+++ b/src/NodeRTCmd/Program.cs
@@ -60,14 +60,14 @@ namespace NodeRTCmd
             string ns = ValueOrNull(argsDictionary, "namespace");
             string customWinMdDir = ValueOrNull(argsDictionary, "customwinmddir");
 
-            VsVersions vsVersion = VsVersions.Vs2017;
+            VsVersions vsVersion = VsVersions.Vs2019;
             WinVersions winVersion = WinVersions.v10;
 
             if (argsDictionary.ContainsKey("vs"))
             {
                 if (!Enum.TryParse<VsVersions>(argsDictionary["vs"], true, out vsVersion))
                 {
-                    Console.WriteLine("Unsupported VS version. Supported options are: VS2017, VS2015, VS2013, VS2012");
+                    Console.WriteLine("Unsupported VS version. Supported options are: VS2019, VS2017, VS2015, VS2013, VS2012");
                     Environment.Exit(1);
                 }
             }
@@ -239,7 +239,7 @@ namespace NodeRTCmd
             Console.WriteLine("  --outdir [path]              The output dir in which the NodeRT module");
             Console.WriteLine("                               will be created in");
             Console.WriteLine();
-            Console.WriteLine("  --vs [Vs2017|Vs2015|Vs2013|Vs2012]  Optional, VS version to use, default is Vs2017");
+            Console.WriteLine("  --vs [Vs2019|Vs2017|Vs2015|Vs2013|Vs2012]  Optional, VS version to use, default is Vs2019");
             Console.WriteLine();
             Console.WriteLine("  --winver [10|8.1|8]          Optional, Windows SDK version to use, default is 10");
             Console.WriteLine();

--- a/src/NodeRTLib/NodeRTProjectBuildUtils.cs
+++ b/src/NodeRTLib/NodeRTProjectBuildUtils.cs
@@ -47,6 +47,9 @@ namespace NodeRTLib
                 case VsVersions.Vs2017:
                     versionString = "2017";
                     break;
+                case VsVersions.Vs2019:
+                    versionString = "2019";
+                    break;
                 default:
                     throw new Exception("Unknown VS Version");
             }

--- a/src/NodeRTLib/NodeRTProjectGenerator.cs
+++ b/src/NodeRTLib/NodeRTProjectGenerator.cs
@@ -26,7 +26,8 @@ namespace NodeRTLib
         Vs2012,
         Vs2013,
         Vs2015,
-        Vs2017
+        Vs2017,
+        Vs2019
     }
 
     public enum WinVersions
@@ -98,8 +99,10 @@ namespace NodeRTLib
                     return "2013";
                 case VsVersions.Vs2015:
                     return "2015";
-                default:
+                case VsVersions.Vs2017:
                     return "2017";
+                default:
+                    return "2019";
             }
         }
 
@@ -291,8 +294,10 @@ namespace NodeRTLib
                 packageJsonFileText.Replace("{VSVersion}", "2013");
             else if (_vsVersion == VsVersions.Vs2015)
                 packageJsonFileText.Replace("{VSVersion}", "2015");
-            else
+            else if (_vsVersion == VsVersions.Vs2017)
                 packageJsonFileText.Replace("{VSVersion}", "2017");
+            else
+                packageJsonFileText.Replace("{VSVersion}", "2019");
 
             File.WriteAllText(Path.Combine(destinationFolder, "package.json"), packageJsonFileText.ToString());
 

--- a/src/NodeRTLib/ProjectTemplates/binding.gyp
+++ b/src/NodeRTLib/ProjectTemplates/binding.gyp
@@ -51,7 +51,9 @@
           "VCCLCompilerTool": {
             "AdditionalUsingDirectories": [
               "%ProgramFiles(x86)%/Microsoft Visual Studio 14.0/VC/lib/store/references",
-              "%ProgramFiles%/Microsoft Visual Studio 14.0/VC/lib/store/references"
+              "%ProgramFiles%/Microsoft Visual Studio 14.0/VC/lib/store/references",
+              "%ProgramFiles(x86)%/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.24.28314/lib/x86/store/references",
+              "%VCToolsInstallDir%/lib/x86/store/references"
             ]
           }
         }

--- a/src/NodeRTUI/App.config
+++ b/src/NodeRTUI/App.config
@@ -18,7 +18,7 @@
                 <value />
             </setting>
             <setting name="VsVersionComboSelection" serializeAs="String">
-                <value>3</value>
+                <value>4</value>
             </setting>
             <setting name="OutputDirPath" serializeAs="String">
                 <value />

--- a/src/NodeRTUI/MainForm.Designer.cs
+++ b/src/NodeRTUI/MainForm.Designer.cs
@@ -268,7 +268,8 @@ namespace NodeRTUI
             "VS 2012 Project",
             "VS 2013 Project",
             "VS 2015 Project",
-            "VS 2017 Project"});
+            "VS 2017 Project",
+            "VS 2019 Project"});
             this.cmbVsVersion.Location = new System.Drawing.Point(386, 588);
             this.cmbVsVersion.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.cmbVsVersion.Name = "cmbVsVersion";

--- a/src/NodeRTUI/MainForm.cs
+++ b/src/NodeRTUI/MainForm.cs
@@ -88,7 +88,7 @@ namespace NodeRTUI
         {
             Properties.Settings.Default.LastWinMDPath = "";
             Properties.Settings.Default.LastFilter = "";
-            Properties.Settings.Default.VsVersionComboSelection = 3;
+            Properties.Settings.Default.VsVersionComboSelection = 4;
             Properties.Settings.Default.OutputDirPath = GetDefaultOutputDir();
             Properties.Settings.Default.GenerateDefsChk = true;
             Properties.Settings.Default.Save();
@@ -98,7 +98,7 @@ namespace NodeRTUI
             txtFilter.Text = "";
             txtOutputDirectory.Text = Properties.Settings.Default.OutputDirPath;
             cmbWindowsVersion.SelectedIndex = 2;
-            cmbVsVersion.SelectedIndex = 3;
+            cmbVsVersion.SelectedIndex = 4;
             chkDefGen.Checked = true;
             chkBuildModule.Checked = true;
             namespaceList.Items.Clear();

--- a/src/NodeRTUI/Properties/Settings.settings
+++ b/src/NodeRTUI/Properties/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="VsVersionComboSelection" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">3</Value>
+      <Value Profile="(Default)">4</Value>
     </Setting>
     <Setting Name="OutputDirPath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />


### PR DESCRIPTION
Adds default support for building with Visual Studio 2019. Note that %VCToolsInstallDir%, referenced in the generated binding.gyp files, is only set by default in the "Developer Command Prompt for VS 2019."