### PR TITLE
Fix build issues on case sensitive systems

### DIFF
--- a/src/NodeRTLib/ProjectFiles/OpaqueWrapper.h
+++ b/src/NodeRTLib/ProjectFiles/OpaqueWrapper.h
@@ -18,7 +18,7 @@
 #include <node.h>
 #include <v8.h>
 #include <string>
-#include "NodeRTUtils.h"
+#include "NodeRtUtils.h"
 #include "WrapperBase.h"
 #include "nan.h"
 #include "nan_object_wrap.h"


### PR DESCRIPTION
While building a project that relies on NodeRT on Windows, the `node-gyp rebuild` phase fails with:

`<folder>\node_modules\@nodert-win10-rs4\windows.data.xml.dom\OpaqueWrapper.h(21,10): fatal error C1083: Cannot open include file: 'NodeRTUtils.h': No such file or directory`

Looking at the files in question, I see that `src/NodeRTLib/ProjectFiles/NodeRtUtils.h` has a lowercase `T`. Fixing it in the file as here allows `node-gyp rebuild` to pass.